### PR TITLE
add zipping mechanism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
  "smallvec",
  "tokio",
  "tokio-util",
- "tracing",
+ "tracing 0.1.37",
  "zstd 0.12.3+zstd.1.5.2",
 ]
 
@@ -88,7 +88,7 @@ dependencies = [
  "http",
  "regex",
  "serde",
- "tracing",
+ "tracing 0.1.37",
 ]
 
 [[package]]
@@ -116,7 +116,7 @@ dependencies = [
  "num_cpus",
  "socket2",
  "tokio",
- "tracing",
+ "tracing 0.1.37",
 ]
 
 [[package]]
@@ -1008,7 +1008,7 @@ checksum = "3c2f0dc9a68c6317d884f97cc36cf5a3d20ba14ce404227df55e1af708ab04bc"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
- "constant_time_eq",
+ "constant_time_eq 0.2.5",
 ]
 
 [[package]]
@@ -1019,7 +1019,7 @@ checksum = "6637f448b9e61dfadbdcbae9a885fadee1f3eaffb1f8d3c1965d3ade8bdfd44f"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
- "constant_time_eq",
+ "constant_time_eq 0.2.5",
 ]
 
 [[package]]
@@ -1032,7 +1032,7 @@ dependencies = [
  "arrayvec 0.7.2",
  "cc",
  "cfg-if",
- "constant_time_eq",
+ "constant_time_eq 0.2.5",
 ]
 
 [[package]]
@@ -1233,6 +1233,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "238e4886760d98c4f899360c834fa93e62cf7f721ac3c2da375cbdf4b8679aae"
 dependencies = [
  "bytes",
+]
+
+[[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1539,7 +1560,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
- "tracing",
+ "tracing 0.1.37",
  "tracing-core",
  "tracing-subscriber 0.3.17",
 ]
@@ -1549,6 +1570,12 @@ name = "const-oid"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"
@@ -1891,7 +1918,7 @@ dependencies = [
  "sp-core",
  "sp-domains",
  "sp-runtime",
- "tracing",
+ "tracing 0.1.37",
 ]
 
 [[package]]
@@ -2487,7 +2514,7 @@ dependencies = [
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
- "tracing",
+ "tracing 0.1.37",
 ]
 
 [[package]]
@@ -2512,7 +2539,7 @@ dependencies = [
  "subspace-core-primitives",
  "subspace-wasm-tools",
  "system-runtime-primitives",
- "tracing",
+ "tracing 0.1.37",
 ]
 
 [[package]]
@@ -2572,7 +2599,7 @@ dependencies = [
  "system-runtime-primitives",
  "thiserror",
  "tokio",
- "tracing",
+ "tracing 0.1.37",
 ]
 
 [[package]]
@@ -2590,7 +2617,7 @@ dependencies = [
  "sp-core",
  "sp-domains",
  "sp-runtime",
- "tracing",
+ "tracing 0.1.37",
 ]
 
 [[package]]
@@ -2617,7 +2644,7 @@ dependencies = [
  "sp-messenger",
  "sp-runtime",
  "system-runtime-primitives",
- "tracing",
+ "tracing 0.1.37",
 ]
 
 [[package]]
@@ -2741,7 +2768,7 @@ dependencies = [
  "substrate-frame-rpc-system",
  "substrate-prometheus-endpoint",
  "system-runtime-primitives",
- "tracing",
+ "tracing 0.1.37",
 ]
 
 [[package]]
@@ -4119,7 +4146,7 @@ dependencies = [
  "slab",
  "tokio",
  "tokio-util",
- "tracing",
+ "tracing 0.1.37",
 ]
 
 [[package]]
@@ -4374,7 +4401,7 @@ dependencies = [
  "socket2",
  "tokio",
  "tower-service",
- "tracing",
+ "tracing 0.1.37",
  "want",
 ]
 
@@ -4739,7 +4766,7 @@ dependencies = [
  "jsonrpsee-types",
  "jsonrpsee-wasm-client",
  "jsonrpsee-ws-client",
- "tracing",
+ "tracing 0.1.37",
 ]
 
 [[package]]
@@ -4763,7 +4790,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tracing",
+ "tracing 0.1.37",
  "webpki-roots",
 ]
 
@@ -4792,7 +4819,7 @@ dependencies = [
  "soketto",
  "thiserror",
  "tokio",
- "tracing",
+ "tracing 0.1.37",
  "wasm-bindgen-futures",
 ]
 
@@ -4812,7 +4839,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tracing",
+ "tracing 0.1.37",
 ]
 
 [[package]]
@@ -4847,7 +4874,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tower",
- "tracing",
+ "tracing 0.1.37",
 ]
 
 [[package]]
@@ -4861,7 +4888,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "tracing",
+ "tracing 0.1.37",
 ]
 
 [[package]]
@@ -7369,6 +7396,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7396,6 +7434,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
  "digest 0.10.6",
+ "hmac 0.12.1",
+ "password-hash",
+ "sha2 0.10.6",
 ]
 
 [[package]]
@@ -7900,7 +7941,7 @@ dependencies = [
  "slab",
  "thiserror",
  "tinyvec",
- "tracing",
+ "tracing 0.1.37",
  "webpki 0.22.0",
 ]
 
@@ -8788,7 +8829,7 @@ dependencies = [
  "subspace-farmer-components",
  "subspace-networking",
  "subspace-rpc-primitives",
- "tracing",
+ "tracing 0.1.37",
 ]
 
 [[package]]
@@ -8811,7 +8852,7 @@ dependencies = [
  "sp-trie",
  "sp-version",
  "sp-wasm-interface",
- "tracing",
+ "tracing 0.1.37",
  "wasmi",
 ]
 
@@ -8998,7 +9039,7 @@ dependencies = [
  "sc-peerset",
  "sp-runtime",
  "substrate-prometheus-endpoint",
- "tracing",
+ "tracing 0.1.37",
 ]
 
 [[package]]
@@ -9105,7 +9146,7 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "threadpool",
- "tracing",
+ "tracing 0.1.37",
 ]
 
 [[package]]
@@ -9282,7 +9323,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "tracing",
+ "tracing 0.1.37",
  "tracing-futures",
 ]
 
@@ -9390,7 +9431,7 @@ dependencies = [
  "sp-runtime",
  "sp-tracing",
  "thiserror",
- "tracing",
+ "tracing 0.1.37",
  "tracing-log 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-subscriber 0.2.25",
 ]
@@ -10425,7 +10466,7 @@ dependencies = [
  "sp-std",
  "sp-tracing",
  "sp-trie",
- "tracing",
+ "tracing 0.1.37",
  "tracing-core",
 ]
 
@@ -10631,7 +10672,7 @@ dependencies = [
  "sp-std",
  "sp-trie",
  "thiserror",
- "tracing",
+ "tracing 0.1.37",
 ]
 
 [[package]]
@@ -10674,7 +10715,7 @@ source = "git+https://github.com/subspace/substrate?rev=fdb68194ab6995447610b3db
 dependencies = [
  "parity-scale-codec",
  "sp-std",
- "tracing",
+ "tracing 0.1.37",
  "tracing-core",
  "tracing-subscriber 0.2.25",
 ]
@@ -10722,7 +10763,7 @@ dependencies = [
  "sp-core",
  "sp-std",
  "thiserror",
- "tracing",
+ "tracing 0.1.37",
  "trie-db",
  "trie-root",
 ]
@@ -10994,7 +11035,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml 0.7.3",
- "tracing",
+ "tracing 0.1.37",
  "tracing-appender",
  "tracing-bunyan-formatter",
  "tracing-error",
@@ -11026,7 +11067,7 @@ dependencies = [
  "spin 0.9.8",
  "static_assertions",
  "thiserror",
- "tracing",
+ "tracing 0.1.37",
  "uint",
 ]
 
@@ -11083,7 +11124,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "tracing",
+ "tracing 0.1.37",
  "tracing-subscriber 0.3.17",
  "ulid",
  "zeroize",
@@ -11112,7 +11153,7 @@ dependencies = [
  "subspace-verification",
  "thiserror",
  "tokio",
- "tracing",
+ "tracing 0.1.37",
 ]
 
 [[package]]
@@ -11138,7 +11179,7 @@ dependencies = [
  "sp-trie",
  "subspace-wasm-tools",
  "system-runtime-primitives",
- "tracing",
+ "tracing 0.1.37",
 ]
 
 [[package]]
@@ -11173,7 +11214,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "tracing",
+ "tracing 0.1.37",
  "tracing-subscriber 0.3.17",
  "unsigned-varint",
 ]
@@ -11357,7 +11398,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tracing",
+ "tracing 0.1.37",
  "tracing-futures",
 ]
 
@@ -11426,7 +11467,7 @@ dependencies = [
  "substrate-prometheus-endpoint",
  "thiserror",
  "tokio",
- "tracing",
+ "tracing 0.1.37",
 ]
 
 [[package]]
@@ -11463,7 +11504,7 @@ dependencies = [
  "sp-runtime",
  "sp-transaction-pool",
  "substrate-prometheus-endpoint",
- "tracing",
+ "tracing 0.1.37",
 ]
 
 [[package]]
@@ -11895,7 +11936,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "tracing",
+ "tracing 0.1.37",
  "windows-sys 0.45.0",
 ]
 
@@ -11955,7 +11996,7 @@ dependencies = [
  "futures-sink",
  "pin-project-lite 0.2.9",
  "tokio",
- "tracing",
+ "tracing 0.1.37",
 ]
 
 [[package]]
@@ -12029,7 +12070,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
+ "tracing 0.1.37",
  "tracing-futures",
 ]
 
@@ -12050,7 +12091,7 @@ dependencies = [
  "tokio-util",
  "tower-layer",
  "tower-service",
- "tracing",
+ "tracing 0.1.37",
 ]
 
 [[package]]
@@ -12086,8 +12127,10 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 [[package]]
 name = "tracing"
 version = "0.1.37"
-source = "git+https://github.com/tokio-rs/tracing?branch=v0.1.x#e35265a0a1dc50521cf599612873b787f7b7b52f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
+ "cfg-if",
  "log",
  "pin-project-lite 0.2.9",
  "tracing-attributes",
@@ -12095,20 +12138,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.38"
+source = "git+https://github.com/ozgunozerk/tracing?branch=v0.1.x#daa710658cf93b417376083cadbe820fbe495ff3"
+dependencies = [
+ "pin-project-lite 0.2.9",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-appender"
 version = "0.2.2"
-source = "git+https://github.com/tokio-rs/tracing?branch=v0.1.x#e35265a0a1dc50521cf599612873b787f7b7b52f"
+source = "git+https://github.com/ozgunozerk/tracing?branch=v0.1.x#8166f4eb1f7a876fa24d881c30d658f9e15f9a66"
 dependencies = [
  "crossbeam-channel",
  "thiserror",
  "time 0.3.20",
  "tracing-subscriber 0.3.17",
+ "zip",
 ]
 
 [[package]]
 name = "tracing-attributes"
 version = "0.1.24"
-source = "git+https://github.com/tokio-rs/tracing?branch=v0.1.x#e35265a0a1dc50521cf599612873b787f7b7b52f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12127,7 +12181,7 @@ dependencies = [
  "serde",
  "serde_json",
  "time 0.3.20",
- "tracing",
+ "tracing 0.1.37",
  "tracing-core",
  "tracing-log 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-subscriber 0.3.17",
@@ -12136,7 +12190,7 @@ dependencies = [
 [[package]]
 name = "tracing-core"
 version = "0.1.30"
-source = "git+https://github.com/tokio-rs/tracing?branch=v0.1.x#e35265a0a1dc50521cf599612873b787f7b7b52f"
+source = "git+https://github.com/ozgunozerk/tracing?branch=v0.1.x#daa710658cf93b417376083cadbe820fbe495ff3"
 dependencies = [
  "once_cell",
  "valuable",
@@ -12145,9 +12199,9 @@ dependencies = [
 [[package]]
 name = "tracing-error"
 version = "0.2.0"
-source = "git+https://github.com/tokio-rs/tracing?branch=v0.1.x#e35265a0a1dc50521cf599612873b787f7b7b52f"
+source = "git+https://github.com/ozgunozerk/tracing?branch=v0.1.x#daa710658cf93b417376083cadbe820fbe495ff3"
 dependencies = [
- "tracing",
+ "tracing 0.1.38",
  "tracing-subscriber 0.3.17",
 ]
 
@@ -12158,7 +12212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
  "pin-project",
- "tracing",
+ "tracing 0.1.37",
 ]
 
 [[package]]
@@ -12175,7 +12229,7 @@ dependencies = [
 [[package]]
 name = "tracing-log"
 version = "0.1.3"
-source = "git+https://github.com/tokio-rs/tracing?branch=v0.1.x#e35265a0a1dc50521cf599612873b787f7b7b52f"
+source = "git+https://github.com/ozgunozerk/tracing?branch=v0.1.x#daa710658cf93b417376083cadbe820fbe495ff3"
 dependencies = [
  "log",
  "once_cell",
@@ -12209,7 +12263,7 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
- "tracing",
+ "tracing 0.1.37",
  "tracing-core",
  "tracing-log 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-serde",
@@ -12218,7 +12272,7 @@ dependencies = [
 [[package]]
 name = "tracing-subscriber"
 version = "0.3.17"
-source = "git+https://github.com/tokio-rs/tracing?branch=v0.1.x#e35265a0a1dc50521cf599612873b787f7b7b52f"
+source = "git+https://github.com/ozgunozerk/tracing?branch=v0.1.x#daa710658cf93b417376083cadbe820fbe495ff3"
 dependencies = [
  "matchers 0.1.0",
  "nu-ansi-term",
@@ -12227,9 +12281,9 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
- "tracing",
+ "tracing 0.1.38",
  "tracing-core",
- "tracing-log 0.1.3 (git+https://github.com/tokio-rs/tracing?branch=v0.1.x)",
+ "tracing-log 0.1.3 (git+https://github.com/ozgunozerk/tracing?branch=v0.1.x)",
 ]
 
 [[package]]
@@ -12286,7 +12340,7 @@ dependencies = [
  "thiserror",
  "tinyvec",
  "tokio",
- "tracing",
+ "tracing 0.1.37",
  "url",
 ]
 
@@ -12306,7 +12360,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "tokio",
- "tracing",
+ "tracing 0.1.37",
  "trust-dns-proto",
 ]
 
@@ -13572,6 +13626,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.15",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e92305c174683d78035cbf1b70e18db6329cc0f1b9cae0a52ca90bf5bfe7125"
+dependencies = [
+ "aes 0.7.5",
+ "byteorder",
+ "bzip2",
+ "constant_time_eq 0.1.5",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "hmac 0.12.1",
+ "pbkdf2 0.11.0",
+ "sha1",
+ "time 0.3.20",
+ "zstd 0.11.2+zstd.1.5.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ thiserror = "1"
 toml = "0.7"
 tokio = { version = "1.27", features = ["macros", "rt-multi-thread", "tracing"] }
 tracing = "0.1.37"
-tracing-appender = "0.2"
+tracing-appender = {version = "0.2", features = ["zipping"] }
 tracing-bunyan-formatter = "0.3.4"
 tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
@@ -49,11 +49,11 @@ console-subscriber = "0.1"
 
 [patch.crates-io]
 # TODO: remove once tracing-appender has a new release
-tracing = { git = "https://github.com/tokio-rs/tracing", branch = "v0.1.x" }
-tracing-appender = { git = "https://github.com/tokio-rs/tracing", branch = "v0.1.x" }
-tracing-core = { git = "https://github.com/tokio-rs/tracing", branch = "v0.1.x" }
-tracing-error = { git = "https://github.com/tokio-rs/tracing", branch = "v0.1.x" }
-tracing-subscriber = { git = "https://github.com/tokio-rs/tracing", branch = "v0.1.x" }
+tracing = { git = "https://github.com/ozgunozerk/tracing", branch = "v0.1.x" }
+tracing-appender = { git = "https://github.com/ozgunozerk/tracing", branch = "v0.1.x"}
+tracing-core = { git = "https://github.com/ozgunozerk/tracing", branch = "v0.1.x" }
+tracing-error = { git = "https://github.com/ozgunozerk/tracing", branch = "v0.1.x" }
+tracing-subscriber = { git = "https://github.com/ozgunozerk/tracing", branch = "v0.1.x" }
 
 [profile.production]
 inherits = "release"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -20,7 +20,7 @@ use crate::config::MIN_PLOT_SIZE;
 use crate::summary::Rewards;
 
 /// for how long a log file should be valid
-const KEEP_LAST_N_FILE: usize = 7;
+const KEEP_LAST_N_FILE: usize = 72;
 
 /// <3
 pub(crate) fn print_ascii_art() {
@@ -225,6 +225,7 @@ pub(crate) fn install_tracing(is_verbose: bool) {
     let file_appender = RollingFileAppender::builder()
         .max_log_files(KEEP_LAST_N_FILE)
         .rotation(Rotation::HOURLY)
+        .zipping(true)
         .filename_prefix("subspace-cli.log")
         .build(log_dir)
         .expect("building should always succeed");


### PR DESCRIPTION
This PR:
- adds zipping mechanism to rotating logs
- also, keeps last 3 days' logs

closes #195 

related pr for upstream: https://github.com/tokio-rs/tracing/pull/2583