### PR TITLE
add merge queue event to ci workflows

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -16,6 +16,8 @@ on:
         required: true
         default: false
         type: boolean
+  merge_group:
+    types: [checks_requested]
 
 env:
   # Not needed in CI, should make things a bit faster

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ on:
   push:
     tags:
       - "*"
+  merge_group:
+    types: [checks_requested]
 
 # Incremental compilation here isn't helpful
 env:

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  merge_group:
+    types: [checks_requested]
 
 env:
   CARGO_INCREMENTAL: 0


### PR DESCRIPTION
- This PR introduces merge [queues](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) to the worflows.