### PR TITLE
Remove merge queue event from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,6 @@ on:
   push:
     tags:
       - "*"
-  merge_group:
-    types: [checks_requested]
 
 # Incremental compilation here isn't helpful
 env:


### PR DESCRIPTION
- Merge queue should not run on release workflow, this corrects #244 