### PR TITLE
Wider support for processors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,8 @@ jobs:
           - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "ubuntu-20.04-x86-64"]' || 'ubuntu-20.04') }}
             target: x86_64-unknown-linux-gnu
             production_target: target/x86_64-unknown-linux-gnu/production
-            suffix: ubuntu-x86_64-skylake-${{ github.ref_name }}
-            rustflags: "-C target-cpu=skylake"
+            suffix: ubuntu-x86_64-broadwell-${{ github.ref_name }}
+            rustflags: "-C target-cpu=x86-64-v3 -C target-feature=+adx"
           - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "ubuntu-20.04-x86-64"]' || 'ubuntu-20.04') }}
             target: aarch64-unknown-linux-gnu
             production_target: target/aarch64-unknown-linux-gnu/aarch64linux
@@ -50,8 +50,8 @@ jobs:
           - os: ${{ fromJson(github.repository_owner == 'subspace' && '["self-hosted", "windows-server-2022-x86-64"]' || 'windows-2022') }}
             target: x86_64-pc-windows-msvc
             production_target: target/x86_64-pc-windows-msvc/production
-            suffix: windows-x86_64-skylake-${{ github.ref_name }}
-            rustflags: "-C target-cpu=skylake"
+            suffix: windows-x86_64-broadwell-${{ github.ref_name }}
+            rustflags: "-C target-cpu=x86-64-v3 -C target-feature=+adx"
 
     runs-on: ${{ matrix.build.os }}
 


### PR DESCRIPTION
Since ADX instructions were introduced starting with the Broadwell architecture, I suggest lowering the threshold from Skylake to x86_64-v3 + ADX instructions.