### PR TITLE
Update pulsar with gemini-3f-2023-oct- snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1672,7 +1672,7 @@ checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 [[package]]
 name = "cross-domain-message-gossip"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -2270,7 +2270,7 @@ dependencies = [
 [[package]]
 name = "domain-block-builder"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -2287,7 +2287,7 @@ dependencies = [
 [[package]]
 name = "domain-block-preprocessor"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "domain-runtime-primitives",
  "parity-scale-codec",
@@ -2311,7 +2311,7 @@ dependencies = [
 [[package]]
 name = "domain-client-consensus-relay-chain"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "async-trait",
  "futures",
@@ -2328,7 +2328,7 @@ dependencies = [
 [[package]]
 name = "domain-client-message-relayer"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "async-channel",
  "cross-domain-message-gossip",
@@ -2354,7 +2354,7 @@ dependencies = [
 [[package]]
 name = "domain-client-operator"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "crossbeam",
  "domain-block-builder",
@@ -2396,7 +2396,7 @@ dependencies = [
 [[package]]
 name = "domain-client-subnet-gossip"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -2415,7 +2415,7 @@ dependencies = [
 [[package]]
 name = "domain-eth-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "clap",
  "domain-runtime-primitives",
@@ -2449,7 +2449,7 @@ dependencies = [
 [[package]]
 name = "domain-pallet-executive"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -2466,7 +2466,7 @@ dependencies = [
 [[package]]
 name = "domain-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -2482,7 +2482,7 @@ dependencies = [
 [[package]]
 name = "domain-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "async-trait",
  "clap",
@@ -2865,7 +2865,7 @@ dependencies = [
 [[package]]
 name = "evm-domain-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "domain-pallet-executive",
  "domain-runtime-primitives",
@@ -6715,7 +6715,7 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 [[package]]
 name = "orml-vesting"
 version = "0.4.1-dev"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6793,7 +6793,7 @@ dependencies = [
 [[package]]
 name = "pallet-domain-id"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6805,7 +6805,7 @@ dependencies = [
 [[package]]
 name = "pallet-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6912,7 +6912,7 @@ dependencies = [
 [[package]]
 name = "pallet-feeds"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6928,7 +6928,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa-finality-verifier"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "finality-grandpa",
  "frame-support",
@@ -6948,7 +6948,7 @@ dependencies = [
 [[package]]
 name = "pallet-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6967,7 +6967,7 @@ dependencies = [
 [[package]]
 name = "pallet-object-store"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6982,7 +6982,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6997,7 +6997,7 @@ dependencies = [
 [[package]]
 name = "pallet-rewards"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7010,7 +7010,7 @@ dependencies = [
 [[package]]
 name = "pallet-runtime-configs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7022,7 +7022,7 @@ dependencies = [
 [[package]]
 name = "pallet-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7081,7 +7081,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-fees"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7137,7 +7137,7 @@ dependencies = [
 [[package]]
 name = "pallet-transporter"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "domain-runtime-primitives",
  "frame-benchmarking",
@@ -7750,7 +7750,7 @@ dependencies = [
 
 [[package]]
 name = "pulsar"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -8686,7 +8686,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -8724,7 +8724,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -8769,7 +8769,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-subspace-rpc"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "async-oneshot",
  "futures",
@@ -9100,7 +9100,7 @@ dependencies = [
 [[package]]
 name = "sc-proof-of-time"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "async-trait",
  "futures",
@@ -9317,7 +9317,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-block-relay"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -9339,7 +9339,7 @@ dependencies = [
 [[package]]
 name = "sc-subspace-chain-specs"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "sc-chain-spec",
  "sc-service",
@@ -10349,7 +10349,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-subspace"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "async-trait",
  "log",
@@ -10466,7 +10466,7 @@ dependencies = [
 [[package]]
 name = "sp-domain-digests"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10478,7 +10478,7 @@ dependencies = [
 [[package]]
 name = "sp-domains"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "blake2",
  "hexlit",
@@ -10593,7 +10593,7 @@ dependencies = [
 [[package]]
 name = "sp-messenger"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "frame-support",
  "hash-db 0.16.0",
@@ -10622,7 +10622,7 @@ dependencies = [
 [[package]]
 name = "sp-objects"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "sp-api",
  "sp-std",
@@ -11072,7 +11072,7 @@ dependencies = [
 [[package]]
 name = "subspace-archiving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "parity-scale-codec",
  "rayon",
@@ -11085,7 +11085,7 @@ dependencies = [
 [[package]]
 name = "subspace-core-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "blake2",
  "blake3",
@@ -11110,7 +11110,7 @@ dependencies = [
 [[package]]
 name = "subspace-erasure-coding"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "blst_rust",
  "kzg",
@@ -11120,7 +11120,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11171,7 +11171,7 @@ dependencies = [
 [[package]]
 name = "subspace-farmer-components"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "async-trait",
  "backoff",
@@ -11201,7 +11201,7 @@ dependencies = [
 [[package]]
 name = "subspace-fraud-proof"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "domain-block-preprocessor",
  "domain-runtime-primitives",
@@ -11225,7 +11225,7 @@ dependencies = [
 [[package]]
 name = "subspace-networking"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "actix-web",
  "async-mutex",
@@ -11267,7 +11267,7 @@ dependencies = [
 [[package]]
 name = "subspace-proof-of-space"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "chacha20 0.9.1",
  "derive_more",
@@ -11280,7 +11280,7 @@ dependencies = [
 [[package]]
 name = "subspace-proof-of-time"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "aes 0.8.3",
  "subspace-core-primitives",
@@ -11290,7 +11290,7 @@ dependencies = [
 [[package]]
 name = "subspace-rpc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "hex",
  "serde",
@@ -11302,7 +11302,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "domain-runtime-primitives",
  "frame-benchmarking",
@@ -11353,7 +11353,7 @@ dependencies = [
 [[package]]
 name = "subspace-runtime-primitives"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -11380,7 +11380,7 @@ dependencies = [
 [[package]]
 name = "subspace-service"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "async-trait",
  "atomic",
@@ -11453,12 +11453,12 @@ dependencies = [
 [[package]]
 name = "subspace-solving"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 
 [[package]]
 name = "subspace-transaction-pool"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "async-trait",
  "domain-runtime-primitives",
@@ -11486,7 +11486,7 @@ dependencies = [
 [[package]]
 name = "subspace-verification"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace?rev=346bcabcec760ce25fec22bbaa69e06c51d9105c#346bcabcec760ce25fec22bbaa69e06c51d9105c"
+source = "git+https://github.com/subspace/subspace?rev=28d4693dace02eab10da69fdfd0d650ea28ff098#28d4693dace02eab10da69fdfd0d650ea28ff098"
 dependencies = [
  "parity-scale-codec",
  "scale-info",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9585,7 +9585,7 @@ dependencies = [
 [[package]]
 name = "sdk-dsn"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace-sdk?rev=ed2d5ae45bf738241659aa2d064bb33b5948d365#ed2d5ae45bf738241659aa2d064bb33b5948d365"
+source = "git+https://github.com/subspace/subspace-sdk?rev=605c2dde41c514fc91a56af23c77e92b4405ca64#605c2dde41c514fc91a56af23c77e92b4405ca64"
 dependencies = [
  "anyhow",
  "derivative",
@@ -9608,7 +9608,7 @@ dependencies = [
 [[package]]
 name = "sdk-farmer"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace-sdk?rev=ed2d5ae45bf738241659aa2d064bb33b5948d365#ed2d5ae45bf738241659aa2d064bb33b5948d365"
+source = "git+https://github.com/subspace/subspace-sdk?rev=605c2dde41c514fc91a56af23c77e92b4405ca64#605c2dde41c514fc91a56af23c77e92b4405ca64"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9641,7 +9641,7 @@ dependencies = [
 [[package]]
 name = "sdk-node"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace-sdk?rev=ed2d5ae45bf738241659aa2d064bb33b5948d365#ed2d5ae45bf738241659aa2d064bb33b5948d365"
+source = "git+https://github.com/subspace/subspace-sdk?rev=605c2dde41c514fc91a56af23c77e92b4405ca64#605c2dde41c514fc91a56af23c77e92b4405ca64"
 dependencies = [
  "anyhow",
  "backoff",
@@ -9706,7 +9706,7 @@ dependencies = [
 [[package]]
 name = "sdk-substrate"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace-sdk?rev=ed2d5ae45bf738241659aa2d064bb33b5948d365#ed2d5ae45bf738241659aa2d064bb33b5948d365"
+source = "git+https://github.com/subspace/subspace-sdk?rev=605c2dde41c514fc91a56af23c77e92b4405ca64#605c2dde41c514fc91a56af23c77e92b4405ca64"
 dependencies = [
  "bytesize",
  "derivative",
@@ -9730,7 +9730,7 @@ dependencies = [
 [[package]]
 name = "sdk-traits"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace-sdk?rev=ed2d5ae45bf738241659aa2d064bb33b5948d365#ed2d5ae45bf738241659aa2d064bb33b5948d365"
+source = "git+https://github.com/subspace/subspace-sdk?rev=605c2dde41c514fc91a56af23c77e92b4405ca64#605c2dde41c514fc91a56af23c77e92b4405ca64"
 dependencies = [
  "async-trait",
  "parking_lot 0.12.1",
@@ -9744,7 +9744,7 @@ dependencies = [
 [[package]]
 name = "sdk-utils"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace-sdk?rev=ed2d5ae45bf738241659aa2d064bb33b5948d365#ed2d5ae45bf738241659aa2d064bb33b5948d365"
+source = "git+https://github.com/subspace/subspace-sdk?rev=605c2dde41c514fc91a56af23c77e92b4405ca64#605c2dde41c514fc91a56af23c77e92b4405ca64"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11366,7 +11366,7 @@ dependencies = [
 [[package]]
 name = "subspace-sdk"
 version = "0.1.0"
-source = "git+https://github.com/subspace/subspace-sdk?rev=ed2d5ae45bf738241659aa2d064bb33b5948d365#ed2d5ae45bf738241659aa2d064bb33b5948d365"
+source = "git+https://github.com/subspace/subspace-sdk?rev=605c2dde41c514fc91a56af23c77e92b4405ca64#605c2dde41c514fc91a56af23c77e92b4405ca64"
 dependencies = [
  "sdk-dsn",
  "sdk-farmer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ single-instance = "0.3.3"
 sp-core = { version = "21.0.0", git = "https://github.com/subspace/substrate", rev = "55c157cff49b638a59d81a9f971f0f9a66829c71", features = ["full_crypto"] }
 strum = "0.24.1"
 strum_macros = "0.24.3"
-subspace-sdk = { git = "https://github.com/subspace/subspace-sdk", rev = "ed2d5ae45bf738241659aa2d064bb33b5948d365" }
+subspace-sdk = { git = "https://github.com/subspace/subspace-sdk", rev = "605c2dde41c514fc91a56af23c77e92b4405ca64" }
 thiserror = "1"
 tokio = { version = "1.27", features = ["macros", "rt-multi-thread", "tracing"] }
 toml = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pulsar"
-version = "0.6.11"
+version = "0.6.12"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
This PR updates pulsar to the latest version of the SDK, utilizing the [gemini-3f-2023-oct-03 snapshot](https://github.com/subspace/subspace/releases/tag/gemini-3f-2023-oct-03)