### PR TITLE
Minor Fix: Build instead of Run

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,10 +149,10 @@ $ cargo build
 
 #### Using cargo
 
-After ensuring the [pre-requisites](#pre-requisites), just run:
+After ensuring the [pre-requisites](#pre-requisites), just build using cargo:
 
 ```sh
-$ cargo run --release
+$ cargo build --release
 ```
 
 This would generate an optimized binary.


### PR DESCRIPTION
This PR is to just add a minor change during installation using cargo. So, instead of `cargo run`, execute `cargo build`. And release mode is opted as it generates optimized binary for installation.