### PR TITLE
Enable subspace block relay for `gemini3g` and `devnet`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8283,7 +8283,7 @@ dependencies = [
 
 [[package]]
 name = "pulsar"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pulsar"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 
 [dependencies]

--- a/src/config.rs
+++ b/src/config.rs
@@ -56,7 +56,8 @@ impl NodeConfig {
                         DsnBuilder::gemini_3g()
                             .provider_storage_path(provider_storage_dir_getter()),
                     )
-                    .sync_from_dsn(true);
+                    .sync_from_dsn(true)
+                    .enable_subspace_block_relay(true);
                 if enable_domains {
                     node = node.domain(Some(DomainConfigBuilder::gemini_3g().configuration()));
                 }
@@ -76,7 +77,9 @@ impl NodeConfig {
             ChainConfig::DevNet => {
                 let mut node = Node::devnet()
                     .network(NetworkBuilder::devnet().name(name))
-                    .dsn(DsnBuilder::devnet().provider_storage_path(provider_storage_dir_getter()));
+                    .dsn(DsnBuilder::devnet().provider_storage_path(provider_storage_dir_getter()))
+                    .sync_from_dsn(true)
+                    .enable_subspace_block_relay(true);
                 if enable_domains {
                     node = node.domain(Some(DomainConfigBuilder::devnet().configuration()));
                 }


### PR DESCRIPTION
# Description 
This PR enables subspace block relay for `gemini3g` and `devnet`. It enables dsn sync for `devnet` as well. This will fix the syncing issue with pulsar.