### PR TITLE
remove merge queue checks

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -16,8 +16,6 @@ on:
         required: true
         default: false
         type: boolean
-  merge_group:
-    types: [checks_requested]
 
 env:
   # Not needed in CI, should make things a bit faster

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-  merge_group:
-    types: [checks_requested]
 
 env:
   CARGO_INCREMENTAL: 0


### PR DESCRIPTION
In this PR merge queue checks are removed from CI workflows; there was a regression that enabled them again from prior PR. It's not necessary for pulsar repo since it's not a busy repository and will unnecessarily run the checks twice.