### PR TITLE
Update "Subspace CLI" to "pulsar" in command info and implementation

### DIFF
--- a/pulsar/src/config.rs
+++ b/pulsar/src/config.rs
@@ -95,7 +95,7 @@ impl NodeConfig {
         node = node
             .role(Role::Authority)
             .impl_version(format!("{}-{}", env!("CARGO_PKG_VERSION"), env!("GIT_HASH")))
-            .impl_name("Subspace CLI".to_string());
+            .impl_name("pulsar".to_string());
 
         crate::utils::apply_extra_options(&node.configuration(), extra)
             .context("Failed to deserialize node config")?

--- a/pulsar/src/main.rs
+++ b/pulsar/src/main.rs
@@ -36,8 +36,8 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 #[derive(Debug, Parser)]
 #[command(subcommand_required = false)]
-#[command(name = "subspace")]
-#[command(about = "Subspace CLI", long_about = None)]
+#[command(name = "pulsar")]
+#[command(about = "pulsar", long_about = None)]
 #[command(version)]
 struct Cli {
     #[command(subcommand)]


### PR DESCRIPTION
There were still remnants of "Subspace CLI" to be found which was showing up in telemetry. This PR removes the last remnants.